### PR TITLE
Add sorting of mounts

### DIFF
--- a/lib/stick/middleware/mount.js
+++ b/lib/stick/middleware/mount.js
@@ -77,7 +77,23 @@ exports.middleware = function Mount(next, app) {
             canonicalPath: spec.canonicalPath,
             app: resolved
         });
+        mounts.sort(mostSpecificPathFirst);
     };
+
+    /**
+     * Sort the mounts array by the most specific mount path first. This means the mount path with
+     * the most slashes in it will be searched first.
+     *
+     * @param m1 mount 1
+     * @param m2 mount 2
+     */
+    function mostSpecificPathFirst(m1, m2) {
+        var slash1 = (m1.path || '').match(/\//g);
+        slash1 = slash1 == null ? 0 : slash1.length;
+        var slash2 = (m2.path || '').match(/\//g);
+        slash2 = slash2 == null ? 0 : slash2.length;
+        return slash2 - slash1;
+    }
 
     // return middleware function
     return function mount(req) {


### PR DESCRIPTION
This commit takes care of sorting the mounts by the number of slashes in their path. It is intended to resolve [Issue 5](https://github.com/hns/stick/issues/5)
