### PR TITLE
Support for REST style URLs

### DIFF
--- a/lib/middleware/mount.js
+++ b/lib/middleware/mount.js
@@ -39,7 +39,7 @@ exports.middleware = function Mount(next, app) {
     var mounts = [];
 
     // define mount() method on application object
-    app.mount = function(spec, target) {
+    app.mount = function(spec, target, useRestUrls) {
         if (typeof spec === "string") {
             spec = {path: spec};
         } else if (!spec) {
@@ -75,6 +75,7 @@ exports.middleware = function Mount(next, app) {
             },
             path: spec.path,
             canonicalPath: spec.canonicalPath,
+            useRestUrls: useRestUrls,
             app: resolved
         });
     };
@@ -88,7 +89,7 @@ exports.middleware = function Mount(next, app) {
             if (mount.match(req)) {
 
                 // if trailing slash is missing redirect to canonical path
-                if (req.pathInfo === mount.path && req.method === "GET") {
+                if (!mount.useRestUrls && req.pathInfo === mount.path && req.method === "GET") {
                     var location = req.scriptName + mount.canonicalPath;
                     if (req.queryString) location += "?" + req.queryString;
                     return {

--- a/test/stick_test.js
+++ b/test/stick_test.js
@@ -67,6 +67,50 @@ exports.testMount = function() {
     testMount(app);
 };
 
+/**
+ * The default behavior of mount.js middleware will issue a 303 redirect if the user enters a mount
+ * path which does not end with a slash on a GET request. The redirect returns the browser to the
+ * same path, but with a trailing slash. Not very nice for performance or style when using REST urls.
+ */
+exports.testNormalUrls = function() {
+    var response;
+
+    var app = new Application();
+    app.configure(mount);
+
+    app.mount("/", function() { return "root" });
+    app.mount("/foo", function() { return "foo" });
+    app.mount("/foo/bar", function() { return "foo/bar" });
+
+    // These URLs should return a 303 response using the default URL treatment
+    response = app({headers: {host: "foo.com"}, method: "GET", env: {}, pathInfo: ""});
+    assert.strictEqual(response.status, 303);
+    response = app({headers: {host: "foo.com"}, method: "GET", env: {}, pathInfo: "/foo"});
+    assert.strictEqual(response.status, 303);
+    response = app({headers: {host: "foo.com"}, method: "GET", env: {}, pathInfo: "/foo/bar"});
+    assert.strictEqual(response.status, 303);
+};
+
+/**
+ * When using the mount command, the developer can choose to use REST-style URLs without a redirect
+ * and without a trailing slash on the end of the URL.
+ */
+exports.testRESTUrls = function() {
+    var response;
+
+    var app = new Application();
+    app.configure(mount);
+
+    app.mount("/", function() { return "root" }, true);
+    app.mount("/foo", function() { return "foo" }, true);
+    app.mount("/foo/bar", function() { return "foo/bar" }, true);
+
+    // Using REST urls, these requests should return the expected content
+    assert.equal(app({headers: {host: "foo.com"}, env: {}, method: "GET", pathInfo: ""}), "root");
+    assert.equal(app({headers: {host: "foo.com"}, env: {}, method: "GET", pathInfo: "/foo"}), "foo");
+    assert.equal(app({headers: {host: "foo.com"}, env: {}, method: "GET", pathInfo: "/foo/bar"}), "foo/bar");
+};
+
 if (require.main == module) {
     require("test").run(exports);
 }


### PR DESCRIPTION
Added support for mounting paths using the typical REST style syntax with no trailing slash. This functionality should be configurable by mount, so a 'useRestUrls' parameter was added to the mount command.

```
function mount( path, controller, useRestUrls );
```

And in usage:

```
var app = new Application();
app.configure(mount);
app.mount("/bar", function() { return "root" }, true);
```

If you omit the useRestUrls parameter or pass false, the application will function as normal, returning a 303 request when the user attempts to access http://example.org/bar.

If you supply a boolean true value for the useRestUrls parameter, the response will be 'root' in the above example.
