### PR TITLE
Additions to session handling

### DIFF
--- a/lib/middleware/session.js
+++ b/lib/middleware/session.js
@@ -60,6 +60,8 @@ exports.middleware = function session(next, app) {
 var ServletSession = exports.ServletSession = function(request) {
 
     var data;
+    var volatileData;
+    
     var servletRequest = request instanceof javax.servlet.ServletRequest ?
             request : request.env.servletRequest;
 
@@ -98,8 +100,60 @@ var ServletSession = exports.ServletSession = function(request) {
             return getSession().isNew();
         }
     });
+    
+    /**
+     * Createtime of the current session.
+     */
+    Object.defineProperty(this, "creationTime", {
+        get: function() {
+            return getSession().getCreationTime();
+        }
+    });
 
+    /**
+     * A time interval in seconds, which the session will be open.
+     * If the interval is exceeded, the session gets invalidated.
+     */
+    Object.defineProperty(this, "maxInactiveInterval", {
+        get: function() {
+            return getSession().getMaxInactiveInterval();
+        },
+        set: function(interval) {
+            return getSession().setMaxInactiveInterval(interval); 
+        }
+    });
+    
+    /**
+     * Time in Unix epoch milliseconds since the last client access.
+     */
+    Object.defineProperty(this, "lastAccessedTime", {
+        get: function() {
+            return getSession().getLastAccessedTime();
+        }
+    });
+
+    /**
+     * Destroys the current session and any data bound to it.
+     */
     this.invalidate = function() {
-       getSession().invalidate();
+        getSession().invalidate();
     };
+    
+    // save and reset the volatile session object
+    volatileData = getSession().getAttribute("__volatileData__");
+    getSession().setAttribute("__volatileData__", null);
+    
+    /**
+     * A volatile property which survives a HTTP redirect and can be used
+     * for warnings or error messages in forms. After a requests was handled,
+     * the property is reset to null.
+     */
+    Object.defineProperty(this, "volatile", {
+        get: function() {
+            return volatileData;
+        },
+        set: function(value) {
+            getSession().setAttribute("__volatileData__", value);
+        }
+    });
 };


### PR DESCRIPTION
I added functions to access the basic session methods and properties in the middleware. Four new properties and one function:
- volatile – this behaves like Helma's res.message
- creationTime
- maxInactiveInterval
- lastAccessedTime
- invalidate – this invalidates the session
