### PR TITLE
xss possible in notfound middleware

### DIFF
--- a/lib/middleware/notfound.js
+++ b/lib/middleware/notfound.js
@@ -17,6 +17,9 @@
  * @param {Object} app the Stick Application object
  * @returns {Function} a JSGI middleware function
  */
+
+var {escapeHtml} = require("ringo/utils/strings");
+
 exports.middleware = function notfound(next, app) {
 
     app.notfound = {
@@ -34,7 +37,7 @@ exports.middleware = function notfound(next, app) {
                         return app.notfound.title || "Not Found";
                     case "body":
                         return app.notfound.body || "<p>The requested URL <b>"
-                                + request.scriptName + request.pathInfo
+                                + escapeHtml(request.scriptName) + escapeHtml(request.pathInfo)
                                 + "</b> was not found on the server.</p>";
                     default:
                         return "";


### PR DESCRIPTION
the notfound response html code contains the unmodified request scriptName and pathInfo, which allows xss. the pull request encodes scriptName too just to be sure (i don't know if this is really necessary).
