### PR TITLE
multiple static() calls

### DIFF
--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -4,9 +4,11 @@
  * This installs a `static()` method in the application that accepts the following arguments:
  *
  *  * `base`: the base resource directory (required)
- * 
+ *
  *  * `index`: the name of a file to serve if the path matches a directory (e.g.
  *    "index.html")
+ *
+ * You can call `static()` multiple times to register multiple resources to be served.
  */
 
 var response = require("ringo/jsgi/response");
@@ -20,10 +22,11 @@ var {mimeType} = require("ringo/mime");
  * @returns {Function} a JSGI middleware function
  */
 exports.middleware = function static(next, app) {
-    
-    var baseRepository, indexDocument;
+
+    var resourceConfigs = [];
 
     app.static = function(base, index) {
+        var baseRepository, indexDocument;
         if (typeof base === "string") {
             baseRepository = getRepository(base);
         } else if (base instanceof org.ringojs.repository.Repository) {
@@ -32,17 +35,20 @@ exports.middleware = function static(next, app) {
             throw new Error ("base must be of type String or Repository");
         }
         baseRepository.setRoot();
-        indexDocument = index;
+        resourceConfigs.push({
+            repository: baseRepository,
+            index: index
+        });
     };
 
     return function static(request) {
-        if (baseRepository) {
+        for each (var config in resourceConfigs) {
             var path = request.pathInfo;
-            if (indexDocument && path.charAt(path.length-1) === "/") {
-                path += indexDocument;
+            if (config.index && path.charAt(path.length-1) === "/") {
+                path += config.index;
             }
             if (path.length > 1) {
-                var resource = baseRepository.getResource(path);
+                var resource = config.repository.getResource(path);
                 if (resource && resource.exists()) {
                     return response.static(resource, mimeType(path, "text/plain"));
                 }


### PR DESCRIPTION
the content of multiple directories can now be served by one static middleware; simply call `app.static(fooDirectory)` repeatedly.

the lookup order, when searching for a file, is the order the directories were added. so a later directory will shadow the content of a former.
