### PR TITLE
Add 'Vary: Origin' header

### DIFF
--- a/lib/middleware/cors.js
+++ b/lib/middleware/cors.js
@@ -105,6 +105,8 @@ exports.middleware = function cors(next, app) {
                 if (config.allowCredentials === true) {
                     res.addHeaders({'Access-Control-Allow-Credentials': 'true'});
                 }
+                // 6.4
+                res.addHeaders({'Vary': 'Origin'});
                 res.addHeaders({'Access-Control-Allow-Origin': requestOrigin});
             }
         }


### PR DESCRIPTION
if Access-Control-Allow-Origin is generated dynamically, we should add 'Vary: Origin' header so responses for different origins are not cached

see http://www.w3.org/TR/cors/#resource-implementation
