### PR TITLE
'Vary: Origin' header should even be sent on non-CORS-request ...

### DIFF
--- a/lib/middleware/cors.js
+++ b/lib/middleware/cors.js
@@ -105,11 +105,12 @@ exports.middleware = function cors(next, app) {
                 if (config.allowCredentials === true) {
                     res.addHeaders({'Access-Control-Allow-Credentials': 'true'});
                 }
-                // 6.4
-                res.addHeaders({'Vary': 'Origin'});
                 res.addHeaders({'Access-Control-Allow-Origin': requestOrigin});
             }
         }
+        // 6.4
+        res.addHeaders({'Vary': 'Origin'});
+
         return res || response.bad();
     }
 };


### PR DESCRIPTION
... (if there is no Origin header), because otherwise such a request could be cached and used to answer a CORS request (which would then fail)
