### PR TITLE
added support for named routes (similar to what django does)

### DIFF
--- a/lib/middleware/route.js
+++ b/lib/middleware/route.js
@@ -29,7 +29,8 @@
  * The route middleware supports generating URLs from route names and parameters
  * required by the route.
  *
- * Routes names are derived from the route's path spec by stripping
+ * Routes names can either be defined explicitly by passing the route name
+ * as third argument, or are derived from the route's path spec by stripping
  * out all placeholders and removing a leading slash. For example, a path
  * spec `/post/:id.html` results in route name "post.html". If a path spec
  * does not contain any static part, its route name is "index".
@@ -45,6 +46,7 @@
  * @example
  * app.configure("route")
  * app.get("/", function() {...})
+ * app.get("/", function() {...}, "index")
  * app.post("/", function(req) {...})
  * app.get("/:id.:format?", function(req, id, format) {...})
  * app.del("/:id", function(req, id) {...})
@@ -64,7 +66,7 @@ exports.middleware = function route(next, app) {
     var routes = {},
         reverse = {};
 
-    function addRoute(method, path, fn) {
+    function addRoute(method, path, fn, name) {
         var keys = [];
         var spec = {keys: keys, fn: fn};
         spec.pattern = path instanceof RegExp ? path : normalizePath(path, keys);
@@ -73,10 +75,14 @@ exports.middleware = function route(next, app) {
 
         // register name -> route lookup
         var rev = {path: path, keys: keys};
-        // extract literal path components as route name, or "index" if none is found
-        var name = "", re = /([\/\.])(\w+)/g, match;
-        for (match = re.exec(path); match != null; match = re.exec(path)) {
-            name += name || match[1] == "." ? match[1] + match[2] : match[2];
+        if (typeof(name) !== "string" || name.length < 1) {
+            // extract literal path components as route name, or "index"
+            // if none is found
+            name = "";
+            var re = /([\/\.])(\w+)/g, match;
+            for (match = re.exec(path); match != null; match = re.exec(path)) {
+                name += name || match[1] == "." ? match[1] + match[2] : match[2];
+            }
         }
         name = spec.name = name || "index";
         if (!reverse[name]) {

--- a/test/stick_test.js
+++ b/test/stick_test.js
@@ -1,6 +1,7 @@
 var {Application} = require("../lib/stick");
 var {mount,route} = require("../lib/middleware")
 var assert = require("assert");
+var {urlFor} = require("../lib/helpers");
 
 
 exports.testMiddleware = function() {
@@ -191,6 +192,58 @@ exports.testMountAndRouteResolution = function() {
     testPath("/test/baz/123/qux", "baz/123/qux");
 };
 
+exports.testUrlForRoute = function() {
+    var app = new Application();
+    app.configure(route);
+    app.get("/:param", function() {});
+    app.get("/foo", function() {});
+    app.get("/foo/:param", function() {});
+    app.get("/bar/foo", function() {});
+    app.get("/bar/:param", function() {});
+    app.get("/baz/:param/qux", function() {});
+    app.get("/baz/:param.html", function() {});
+    assert.strictEqual(urlFor(app, {"param": "foo"}), "/foo");
+    assert.strictEqual(urlFor(app, {"action": "index", "param": "foo"}), "/foo");
+    // additional bindigs are added as query parameters
+    assert.strictEqual(urlFor(app, {"action": "foo", "bar": "baz"}), "/foo?bar=baz");
+    // non-matching route name - additional bindings are added too
+    assert.strictEqual(urlFor(app, {"action": "nonexisting", "bar": "baz"}),
+            "/_nonexisting_(unknown_route)?bar=baz");
+    // note: `/foo` and `/foo/:param` routes have the same literal name, so
+    // only the first one defined is known by route middleware
+    assert.strictEqual(urlFor(app, {"action": "foo", "param": 123}), "/foo?param=123");
+    assert.strictEqual(urlFor(app, {"action": "bar/foo"}), "/bar/foo");
+    assert.strictEqual(urlFor(app, {"action": "bar", "param": "baz"}), "/bar/baz");
+    assert.strictEqual(urlFor(app, {"action": "baz/qux", "param": 123}), "/baz/123/qux");
+    assert.strictEqual(urlFor(app, {"action": "baz.html", "param": 123}), "/baz/123.html");
+
+    var mountApp = new Application();
+    mountApp.configure(mount);
+    mountApp.mount("/test", app);
+    assert.strictEqual(urlFor(app, {"param": "foo"}), "/test/foo");
+    assert.strictEqual(urlFor(app, {"action": "index", "param": "bar"}), "/test/bar");
+    assert.strictEqual(urlFor(app, {"action": "nonexisting", "bar": "baz"}),
+            "/test/_nonexisting_(unknown_route)?bar=baz");
+    assert.strictEqual(urlFor(app, {"action": "bar", "param": 123}), "/test/bar/123");
+    assert.strictEqual(urlFor(app, {"action": "baz.html", "param": 123}), "/test/baz/123.html");
+};
+
+exports.testUrlForNamedRoute = function() {
+    var app = new Application();
+    app.configure(route);
+    app.get("/:param", function() {}, "param");
+    app.get("/foo", function() {}, "fooindex");
+    app.get("/foo/:id", function() {}, "foodetail");
+    app.get("/bar/:id", function() {}, "bardetail");
+    app.get("/bar/:id.:format", function() {}, "bardetailformat");
+    assert.strictEqual(urlFor(app, {"action": "param", "param": "test"}), "/test");
+    assert.strictEqual(urlFor(app, {"action": "fooindex"}), "/foo");
+    assert.strictEqual(urlFor(app, {"action": "foodetail", "id": 123}), "/foo/123");
+    assert.strictEqual(urlFor(app, {"action": "bardetail", "id": 123}), "/bar/123");
+    assert.strictEqual(urlFor(app, {"action": "bardetailformat", "id": 123, "format": "html"}),
+            "/bar/123.html");
+};
+
 exports.testSimpleCors = function() {
    var {text} = require('ringo/jsgi/response');
    var app = new Application();
@@ -361,5 +414,5 @@ exports.testPreflightCors = function() {
 }
 
 if (require.main == module) {
-    require("test").run(exports);
+    require("test").run(exports, arguments[1]);
 }


### PR DESCRIPTION
stick's route name generation fails in certain situations (eg. the
two routes `/items/:day` and `/items/:day/:id` get the same literal
name, but only the first one would be registered. reverse resolution
of the second rule isn't possible anymore).

explicitly specifying a name for routes prevents that. route names can
be passed as third argument when defining them.
