### PR TITLE
Add additional configuration features to params middleware

### DIFF
--- a/lib/middleware/params.js
+++ b/lib/middleware/params.js
@@ -15,7 +15,7 @@
  * </ul>
  *
  * @example const app = new Application();
- * app.configure(params, route);
+ * app.configure("params", "route");
  * app.params({
  *   limit: 10,
  *   reviver: function(key, val) {

--- a/lib/middleware/params.js
+++ b/lib/middleware/params.js
@@ -18,6 +18,7 @@
  * app.configure("params", "route");
  * app.params({
  *   limit: 10,
+ *   strict: true,
  *   reviver: function(key, val) {
  *     return (typeof val === "number") ? val * 2 : val;
  *   }

--- a/lib/middleware/params.js
+++ b/lib/middleware/params.js
@@ -1,9 +1,38 @@
 /**
  * @fileoverview This module provides middleware for parsing
- * HTTP parameters from the query string and request body.
+ * HTTP parameters from the query string and request body. It does not parse
+ * multipart MIME data such as file uploads which are handled by the [upload][(../upload) module.
  *
- * It does not parse multipart MIME data such as file uploads which are handled
- * by the [upload][middleware/upload] module.
+ * This installs a `params()` method in the application that accepts a configuration object with
+ * the following properties:
+ *
+ * <ul>
+ *    <li>`limit`: maximum length of the request body in bytes, -1 disables the limit, defaults to 100 KiB</li>
+ *    <li>`strict`: if true (default), only accept JSON following RFC 4627, otherwise also parse pseudo-JSON like "1234"</li>
+ *    <li>`reviver`: optional function to transform the result JSON, see
+ *    <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter">JSON.parse(str, reviver)</a>
+ *    for details</li>
+ * </ul>
+ *
+ * @example const app = new Application();
+ * app.configure(params, route);
+ * app.params({
+ *   limit: 10,
+ *   reviver: function(key, val) {
+ *     return (typeof val === "number") ? val * 2 : val;
+ *   }
+ * });
+ *
+ * app.post("/example-json", function (req) {
+ *   // JSON requests will parsed into req.postParams
+ *   const jsonObj = req.postParams;
+ * };
+ *
+ * app.post("/example-form", function (req) {
+ *   // submitted form params are parsed into req.postParams
+ *   // for application/x-www-form-urlencoded requests
+ *   const formFields = req.postParams;
+ * };
  */
 var {isFileUpload, isUrlEncoded, parseFileUpload, parseParameters,
     mergeParameter, BufferFactory} = require("ringo/utils/http");
@@ -21,6 +50,19 @@ var response = require("ringo/jsgi/response");
  * @returns {Function} a JSGI middleware function
  */
 exports.middleware = function params(next, app) {
+    // allow whitspace: Space, Horizontal tab, Line feed or New line, Carriage return
+    // https://www.ietf.org/rfc/rfc4627.txt
+    const startCharPattern = java.util.regex.Pattern.compile("^[\u0020\u0009\u000A\u000D]*[\\{\\[]");
+
+    let config = {
+        limit: 102400,
+        reviver: null,
+        strict: true
+    };
+
+    app.params = function(mwConfig) {
+        config = objects.merge(mwConfig, config);
+    };
 
     // Custom Error
     function ParamsParseException (message) {
@@ -77,7 +119,13 @@ exports.middleware = function params(next, app) {
                         var input;
                         var encoding = servletRequest.getCharacterEncoding() || "utf8";
                         if (isUrlEncoded(contentType)) {
+                            // check if the body could be parsed inside the req.body limit
+                            if (config.limit >= 0 && req.input.length > config.limit) {
+                                throw new ParamsParseException("Maximum request body size exceeded!");
+                            }
+
                             postParams = {};
+
                             input = req.input.read();
                             var contentLength = parseInt(req.headers["content-length"]);
                             if (!input.length && contentLength > 0) {
@@ -95,9 +143,27 @@ exports.middleware = function params(next, app) {
                                 parseParameters(input, postParams, encoding);
                             }
                         } else if (strings.startsWith(contentType, "application/json")) {
+                            // check if the body could be parsed inside the req.body limit
+                            if (config.limit >= 0 && req.input.length > config.limit) {
+                                throw new ParamsParseException("Maximum request body size exceeded!");
+                            }
+
                             input = req.input.read();
+
                             try {
-                                postParams = JSON.parse(input.decodeToString(encoding));
+                                const jsonStr = input.decodeToString(encoding);
+
+                                // RFC 4627 by Crockford defines a JSON-text = object / array,
+                                // so in strict mode all other values are not allowed.
+                                if (config.strict !== false) {
+                                    // check first character in strict mode
+                                    const fcMatcher = startCharPattern.matcher(jsonStr);
+                                    if (!fcMatcher.find()) {
+                                        throw new ParamsParseException("JSON Parsing Error!");
+                                    }
+                                }
+
+                                postParams = JSON.parse(jsonStr, config.reviver);
                             } catch (e) {
                                 throw new ParamsParseException();
                             }

--- a/lib/middleware/params.js
+++ b/lib/middleware/params.js
@@ -10,7 +10,7 @@
  *    <li><code>limit</code>: maximum length of the request body in bytes, -1 disables the limit, defaults to 100 KiB</li>
  *    <li><code>strict</code>: if true (default), only accept JSON following RFC 4627, otherwise also parse pseudo-JSON like <code>"1234"</code></li>
  *    <li><code>reviver</code>: optional function to transform the result JSON, see
- *    <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter">JSON.parse(str, reviver)</a>
+ *    <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter">JSON.parse(str,&nbsp;reviver)</a>
  *    for details</li>
  * </ul>
  *

--- a/lib/middleware/params.js
+++ b/lib/middleware/params.js
@@ -7,7 +7,7 @@
  * the following properties:
  *
  * <ul>
- *    <li><code>limit<code>: maximum length of the request body in bytes, -1 disables the limit, defaults to 100 KiB</li>
+ *    <li><code>limit</code>: maximum length of the request body in bytes, -1 disables the limit, defaults to 100 KiB</li>
  *    <li><code>strict</code>: if true (default), only accept JSON following RFC 4627, otherwise also parse pseudo-JSON like <code>"1234"</code></li>
  *    <li><code>reviver</code>: optional function to transform the result JSON, see
  *    <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter">JSON.parse(str, reviver)</a>

--- a/lib/middleware/params.js
+++ b/lib/middleware/params.js
@@ -1,15 +1,15 @@
 /**
  * @fileoverview This module provides middleware for parsing
  * HTTP parameters from the query string and request body. It does not parse
- * multipart MIME data such as file uploads which are handled by the [upload][(../upload) module.
+ * multipart MIME data such as file uploads which are handled by the [upload](../upload) module.
  *
  * This installs a `params()` method in the application that accepts a configuration object with
  * the following properties:
  *
  * <ul>
- *    <li>`limit`: maximum length of the request body in bytes, -1 disables the limit, defaults to 100 KiB</li>
- *    <li>`strict`: if true (default), only accept JSON following RFC 4627, otherwise also parse pseudo-JSON like "1234"</li>
- *    <li>`reviver`: optional function to transform the result JSON, see
+ *    <li><code>limit<code>: maximum length of the request body in bytes, -1 disables the limit, defaults to 100 KiB</li>
+ *    <li><code>strict</code>: if true (default), only accept JSON following RFC 4627, otherwise also parse pseudo-JSON like <code>"1234"</code></li>
+ *    <li><code>reviver</code>: optional function to transform the result JSON, see
  *    <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter">JSON.parse(str, reviver)</a>
  *    for details</li>
  * </ul>

--- a/lib/middleware/static.js
+++ b/lib/middleware/static.js
@@ -3,23 +3,25 @@
  *
  * This installs a `static()` method in the application that accepts the following arguments:
  *
- *  * `base`: the base resource directory (required)
- *
- *  * `index`: the name of a file to serve if the path matches a directory (e.g.
- *    "index.html")
- *
- *  * `baseURI`: a common prefix for a resource URI (e.g. "/static")
- *
- *  * `options`: an object with fine-grained configuration options
- *  ** `servePrecompressed`: if true (default), static resources with a pre-compressed gzip equivalent will be
+ * <ul>
+ *  <li>`base`: the base resource directory (required)
+ *  <li>`index`: the name of a file to serve if the path matches a directory (e.g. "index.html")
+ *  <li>`baseURI`: a common prefix for a resource URI (e.g. "/static")
+ *  <li>`options`: an object with fine-grained configuration options
+ *  <li>
+ *     <ul>
+ *     <li>`servePrecompressed`: if true (default), static resources with a pre-compressed gzip equivalent will be
  *                           served instead of the original file.
- *  ** `maxAge`: set the `Cache-Control` header in seconds, default is 0.
- *  ** `lastModified`: if true (default), set the `Last-Modified` header to the modification date of the resource.
- *  ** `setHeaders`: allows a user to specify a function which returns additional headers to be set for a given path.
+ *     <li>`maxAge`: set the `Cache-Control` header in seconds, default is 0.
+ *     <li>`lastModified`: if true (default), set the `Last-Modified` header to the modification date of the resource.
+ *     <li>`setHeaders`: allows a user to specify a function which returns additional headers to be set for a given path.
  *                   The given function produces an object containing the header names as keys and takes the path as
  *                   argument. User-provided headers take precedence over all other headers.
- *  ** `dotfiles`: determines how should files starting with a dot character be treated.
+ *     <li>`dotfiles`: determines how should files starting with a dot character be treated.
  *                 `allow` (default) serves dotfiles, `deny` respond with status 403, `ignore` respond with status 404.
+ *    </ul>
+ *  </li>
+ * </ul>
  *
  * You can call `static()` multiple times to register multiple resources to be served.
  */

--- a/test/middleware/params_test.js
+++ b/test/middleware/params_test.js
@@ -2,6 +2,7 @@ var system = require("system");
 var assert = require("assert");
 var io = require("io");
 var binary = require("binary");
+var response = require("ringo/jsgi/response");
 
 var {Application} = require("../../lib/stick");
 var {route,params} = require("../../lib/middleware");
@@ -24,17 +25,22 @@ var mockRequest = exports.mockRequest = function(method, path, opts) {
 };
 
 exports.testJSONParsing = function() {
-    var app = new Application();
+    const app = new Application();
     app.configure(params, route);
 
     app.post("/good", function (req) {
+        // Access post params, otherwise parser will not be invoked
+        req.postParams;
+
         assert.ok(typeof req.postParams === "object");
         assert.deepEqual(req.postParams, { foo: "bar" });
+        return response.ok().json(req.postParams);
     });
 
     app.post("/bad", function (req) {
-        // Try to access post params
+        // Access post params, otherwise parser will not be invoked
         req.postParams;
+        return response.ok().json({});
     });
 
     app(mockRequest("POST", "/good", {
@@ -44,7 +50,7 @@ exports.testJSONParsing = function() {
         input: new io.MemoryStream(new binary.ByteString("{\"foo\": \"bar\"}", "UTF-8"))
     }));
 
-    var response = app(mockRequest("POST", "/bad", {
+    let res = app(mockRequest("POST", "/bad", {
         headers: {
             "content-type": "application/json"
         },
@@ -52,25 +58,317 @@ exports.testJSONParsing = function() {
     }));
 
     // Check for Bad Request
-    assert.strictEqual(response.status, 400);
+    assert.strictEqual(res.status, 400);
+
+    // Check the reviver support
+    app.params({
+        reviver: function(key, val) {
+            if (typeof val === "number") {
+                return val * 3
+            }
+
+            return val;
+        }
+    });
+
+    app.post("/reviver", function (req) {
+        // Access post params, otherwise parser will not be invoked
+        req.postParams;
+
+        assert.ok(typeof req.postParams === "object");
+        assert.deepEqual(req.postParams, { "num": 3, "str": "foobar" });
+        return response.ok().json(req.postParams);
+    });
+
+    res = app(mockRequest("POST", "/reviver", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("{\"num\": 1, \"str\": \"foobar\" }", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
 };
 
-exports.testPostParamsParsing = function() {
-    var app = new Application();
+exports.testStrictJSONParsing = function() {
+    const app = new Application();
     app.configure(params, route);
 
+    app.post("/tester", function (req) {
+        // Access post params, otherwise parser will not be invoked
+        req.postParams;
+
+        return response.ok().json();
+    });
+
+    let res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("                             {\"foo\": \"bar\"}   ", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("                             []   ", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("                             [[[1], 2], 3]   ", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("[[[1], 2], 3]", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("{}", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 400);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("                             123   ", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 400);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("123", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 400);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("false", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 400);
+
+    app.params({
+        strict: false
+    });
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("                             {\"foo\": \"bar\"}   ", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("                             []   ", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("                             [[[1], 2], 3]   ", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("[[[1], 2], 3]", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("{}", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("   ", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 400);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 400);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("                             123   ", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("123", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+
+    res = app(mockRequest("POST", "/tester", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("false", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+};
+
+exports.testParameterParsingLimit = function() {
+    const app = new Application();
+    app.configure(params, route);
+
+    app.params({
+        limit: 13
+    });
+
     app.post("/good", function (req) {
+        // Access post params, otherwise parser will not be invoked
+        req.postParams;
+
+        assert.ok(typeof req.postParams === "object");
+        assert.deepEqual(req.postParams, { foo: "bar" });
+
+        return response.ok().json({});
+    });
+
+    let res = app(mockRequest("POST", "/good", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("{\"foo\": \"bar\"}", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 400);
+
+    app.params({
+        limit: 14
+    });
+
+    res = app(mockRequest("POST", "/good", {
+        headers: {
+            "content-type": "application/json"
+        },
+        input: new io.MemoryStream(new binary.ByteString("{\"foo\": \"bar\"}", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+
+    app.post("/postparams", function (req) {
+        // Access post params, otherwise parser will not be invoked
+        req.postParams;
+
         assert.ok(typeof req.postParams === "object");
         assert.deepEqual(req.postParams, {
             "Name": "Jonathan Doe",
             "Age": "23",
             "Formula": "a + b == 13%!"
         });
+        return response.ok().json({});
+    });
+
+    app.params({
+        limit: 55
+    });
+
+    res = app(mockRequest("POST", "/postparams", {
+        headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            "content-length": "56"
+        },
+        input: new io.MemoryStream(new binary.ByteString("Name=Jonathan+Doe&Age=23&Formula=a+%2B+b+%3D%3D+13%25%21", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 400);
+
+    app.params({
+        limit: 56
+    });
+
+    res = app(mockRequest("POST", "/postparams", {
+        headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            "content-length": "56"
+        },
+        input: new io.MemoryStream(new binary.ByteString("Name=Jonathan+Doe&Age=23&Formula=a+%2B+b+%3D%3D+13%25%21", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+
+    app.params({
+        limit: -1
+    });
+
+    res = app(mockRequest("POST", "/postparams", {
+        headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            "content-length": "56"
+        },
+        input: new io.MemoryStream(new binary.ByteString("Name=Jonathan+Doe&Age=23&Formula=a+%2B+b+%3D%3D+13%25%21", "UTF-8"))
+    }));
+    assert.strictEqual(res.status, 200);
+};
+
+exports.testPostParamsParsing = function() {
+    const app = new Application();
+    app.configure(params, route);
+
+    app.post("/good", function (req) {
+        // Access post params, otherwise parser will not be invoked
+        req.postParams;
+
+        assert.ok(typeof req.postParams === "object");
+        assert.deepEqual(req.postParams, {
+            "Name": "Jonathan Doe",
+            "Age": "23",
+            "Formula": "a + b == 13%!"
+        });
+        return response.ok().json({});
     });
 
     app(mockRequest("POST", "/good", {
         headers: {
-            "content-type": "application/x-www-form-urlencoded"
+            "content-type": "application/x-www-form-urlencoded",
+            "content-length": "56"
         },
         input: new io.MemoryStream(new binary.ByteString("Name=Jonathan+Doe&Age=23&Formula=a+%2B+b+%3D%3D+13%25%21", "UTF-8"))
     }));


### PR DESCRIPTION
Also  adds a default body size limit of 100 KiB. The new `params()` methods allows to configure:

 * a body size limit
 * JSON strict or relaxed parsing
 * a JSON reviver function