### PR TITLE
fixed issue with ringo-mustache dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Currently Stick comes with the following middleware modules:
  * notfound     - generating 404 pages
  * params       - form data parsing
  * profiler     - JavaScript profiling
- * render       - mustache.js templates
+ * render       - mustache.js templates (use `rp install ringo-mustache`)
  * requestlog   - collecting per-request log messages
  * route        - Sinatra-like request routing
  * session      - session support

--- a/lib/middleware/render.js
+++ b/lib/middleware/render.js
@@ -19,7 +19,7 @@
  * app.render("index.tmpl", {data: "Hello World!"});
  */
 const objects = require("ringo/utils/objects");
-const mustache = require("ringo/mustache");
+const mustache = require("ringo-mustache");
 const {isRelative} = require("fs");
 const {Resource, Repository} =  org.ringojs.repository;
 


### PR DESCRIPTION
mustache is no longer part of RingoJS since 0.12 version, and now comes as a separate dependency: https://github.com/ringo/legacy-modules

`rp install ringo-mustache` have to be used to install it.